### PR TITLE
Derive rpm version from git tag.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,11 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src
 EXTRA_DIST = autogen.sh
+REPO_TAG=$(shell git describe --tags --match "v*" 2>/dev/null | cut -b 2-)
+REPO_TAGFMT=$(shell echo ${REPO_TAG} | sed 's/-g/-/')
+REPO_VER=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 1)
+REPO_REL=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 2,3 | sed 's/-/_/')
+REPO_COMMITS=$(shell git log --oneline | wc -l)
 
 rpmdir=$(abs_builddir)/rpms
 
@@ -12,7 +17,12 @@ rpm: dist
 	mkdir -p $(rpmdir)/BUILD
 	mkdir -p $(rpmdir)/BUILDROOT
 	cp $(distdir).tar.gz $(rpmdir)/SOURCES
-	rpmbuild -ba -D "_topdir $(rpmdir)" $(top_srcdir)/pid1.spec
+	REPO_VER=$(REPO_VER) && REPO_REL=$(REPO_REL) && \
+	rpmbuild -ba \
+           -D "_topdir $(rpmdir)" \
+		   -D "_version $${REPO_VER:=0.0}" \
+		   -D "_release $${REPO_REL:=$(REPO_COMMITS)}" \
+           $(top_srcdir)/pid1.spec
 
 install_rpm:
 	[ ! -z $(rpm_install_dir) ] || echo must run make rpm_install_dir=...

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(pid1, 2.3, andreikeis@noreply.github.com)
+AC_INIT(pid1, m4_esyscmd_s([git describe --tags HEAD --long --match "v*" 2>/dev/null > /dev/null; if [ $? == 0 ]; then git describe --tags HEAD --long --match "v*" 2>/dev/null | cut -b 2- | cut -d '-' -f 1; else echo 0.0; fi]), andreikeis@noreply.users.github.com)
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_SRCDIR(src/pid1.c)
 AM_INIT_AUTOMAKE([tar-pax])

--- a/pid1.spec
+++ b/pid1.spec
@@ -1,6 +1,6 @@
 Name:           pid1
-Version:        2.3
-Release:        2%{?dist}
+Version:        %{_version} 
+Release:        %{_release}%{?dist}
 Summary:        Treadmill pid1 utility.
 
 License:        Apache 2.0


### PR DESCRIPTION
- use tag v<release> to derive rpm version.
- if tag is not found, default to 0.0 version, use # of commits as
  release.