### PR TITLE
Force use of long tags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src
 EXTRA_DIST = autogen.sh
-REPO_TAG=$(shell git describe --tags --match "v*" 2>/dev/null | cut -b 2-)
+REPO_TAG=$(shell git describe --tags --long --match "v*" 2>/dev/null | cut -b 2-)
 REPO_TAGFMT=$(shell echo ${REPO_TAG} | sed 's/-g/-/')
 REPO_VER=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 1)
 REPO_REL=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 2,3 | sed 's/-/_/')


### PR DESCRIPTION
Add --long to the arguments passed to git describe
This fixes a case where a tag matches the latest commit, with no additional commits after the tag. 
Example:
`git tag v1.0`
Without --long, git describe returns:
`v1.0`
With --long, git describe returns the git shortid:
`v1.0-0-gf89902b`